### PR TITLE
Add try/catch to mailable boot

### DIFF
--- a/src/Traits/Mailable.php
+++ b/src/Traits/Mailable.php
@@ -46,7 +46,11 @@ trait Mailable
                     });
             });
         } catch (\Illuminate\Database\QueryException $exception) {
-            \Log::info('Could not bind NovaMailEvents. NovaMail tables might not have migrated yet. This is typical when running fresh migrations during testing or local development.');
+            \Log::info(
+                'Could not bind NovaMailEvents. '
+                . 'NovaMail tables might not have migrated yet, '
+                . 'typical when running fresh migrations during testing or local development.'
+            );
         }
     }
 

--- a/src/Traits/Mailable.php
+++ b/src/Traits/Mailable.php
@@ -15,35 +15,39 @@ trait Mailable
      */
     public static function bootMailable()
     {
-        NovaMailTemplate::whereHas('events', function ($query) {
-            $query->whereModel(get_called_class());
-        })->each(function (NovaMailTemplate $novaMailTemplate) {
-            $novaMailTemplate->events
-                ->filter(function ($event) {
-                    return collect(config('nova_mail.eventables'))->contains($event->model);
-                })
-                ->each(function ($event) use ($novaMailTemplate) {
-                    if ($event->column) {
-                        $event->model::updated(function ($model) use ($novaMailTemplate, $event) {
-                            if ($model->isDirty($event->column)) {
-                                $value = is_bool($model->{$event->column})
-                                    ? filter_var($event->value, FILTER_VALIDATE_BOOLEAN)
-                                    : $event->value;
+        try {
+            NovaMailTemplate::whereHas('events', function ($query) {
+                $query->whereModel(get_called_class());
+            })->each(function (NovaMailTemplate $novaMailTemplate) {
+                $novaMailTemplate->events
+                    ->filter(function ($event) {
+                        return collect(config('nova_mail.eventables'))->contains($event->model);
+                    })
+                    ->each(function ($event) use ($novaMailTemplate) {
+                        if ($event->column) {
+                            $event->model::updated(function ($model) use ($novaMailTemplate, $event) {
+                                if ($model->isDirty($event->column)) {
+                                    $value = is_bool($model->{$event->column})
+                                        ? filter_var($event->value, FILTER_VALIDATE_BOOLEAN)
+                                        : $event->value;
 
-                                if (is_null($event->value) || $model->{$event->column} === $value) {
-                                    $model->sendMailTemplate($novaMailTemplate, $event);
+                                    if (is_null($event->value) || $model->{$event->column} === $value) {
+                                        $model->sendMailTemplate($novaMailTemplate, $event);
+                                    }
                                 }
-                            }
+                            });
+
+                            return;
+                        }
+
+                        $event->model::{$event->name}(function ($model) use ($novaMailTemplate, $event) {
+                            $model->sendMailTemplate($novaMailTemplate, $event);
                         });
-
-                        return;
-                    }
-
-                    $event->model::{$event->name}(function ($model) use ($novaMailTemplate, $event) {
-                        $model->sendMailTemplate($novaMailTemplate, $event);
                     });
-                });
-        });
+            });
+        } catch (\Illuminate\Database\QueryException $exception) {
+            \Log::info('Could not bind NovaMailEvents. NovaMail tables might not have migrated yet. This is typical when running fresh migrations during testing or local development.');
+        }
     }
 
     /**


### PR DESCRIPTION
This addresses #36 

When fresh migrations are run and they create mailable models, NovaMail tables might not exist yet and it will throw an error preventing migrations from running. 