### PR TITLE
NovaSentMail "Sent At" Field formatting fix

### DIFF
--- a/src/Nova/NovaSentMail.php
+++ b/src/Nova/NovaSentMail.php
@@ -58,7 +58,7 @@ class NovaSentMail extends Resource
                     return trim(strip_tags($content));
                 })
                 ->alwaysShow(),
-            DateTime::make('Sent At', 'created_at')->format('M/d/Y h:mm:ss a'),
+            DateTime::make('Sent At', 'created_at')->format('M/D/Y h:mm:ss a'),
         ];
     }
 


### PR DESCRIPTION
Change of datetime formatting to be M/D/Y instead of M/d/Y which for example incorrectly shows 4/21/2021 as 4/3/2021